### PR TITLE
Unconditionally remove libtool helper files.

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -53,7 +53,8 @@ xcb-xvmc
 
 # Prefer dynamic libraries to static, and dump libtool helper files
 for lib_ident in $xcb_libs ; do
+    rm -f $PREFIX/lib/lib${lib_ident}.la
     if [ -e $PREFIX/lib/lib${lib_ident}$SHLIB_EXT ] ; then
-        rm -f $PREFIX/lib/lib${lib_ident}.a $PREFIX/lib/lib${lib_ident}.la
+        rm -f $PREFIX/lib/lib${lib_ident}.a
     fi
 done

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 # versions to cover the different Visual Studio versions.
 
 build:
-  number: 1
+  number: 2
   detect_binary_files_with_prefix: true
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
I tried to be nice but if the files exist at all, they cause problems on Windows.